### PR TITLE
Updated SSM and variable module to reflect changes from upload package buildspec

### DIFF
--- a/martini-upload-package/ssm.tf
+++ b/martini-upload-package/ssm.tf
@@ -3,10 +3,7 @@ resource "aws_ssm_parameter" "martini_upload_package" {
   type = "SecureString"
   value = jsonencode({
     BASE_URL              = var.base_url
-    MARTINI_USER_NAME     = var.martini_user_name
-    MARTINI_USER_PASSWORD = var.martini_user_password
-    CLIENT_ID             = var.client_id
-    client_secret         = var.client_secret
+    MARTINI_ACCESS_TOKEN     = var.martini_access_token
   })
   description = "SSM parameter for Martini build image configurations"
   tags = {

--- a/martini-upload-package/ssm.tf
+++ b/martini-upload-package/ssm.tf
@@ -3,7 +3,7 @@ resource "aws_ssm_parameter" "martini_upload_package" {
   type = "SecureString"
   value = jsonencode({
     BASE_URL              = var.base_url
-    MARTINI_ACCESS_TOKEN     = var.martini_access_token
+    MARTINI_ACCESS_TOKEN  = var.martini_access_token
   })
   description = "SSM parameter for Martini build image configurations"
   tags = {

--- a/martini-upload-package/variable.tf
+++ b/martini-upload-package/variable.tf
@@ -53,22 +53,8 @@ variable "base_url" {
   type        = string
 }
 
-variable "martini_user_name" {
-  description = "The username used to generate the OAuth token from the remote Martini runtime server."
+variable "martini_access_token" {
+  description = "Long-lived OAuth token used to authenticate with the remote Martini runtime server."
   type        = string
 }
 
-variable "martini_user_password" {
-  description = "The password used to generate the OAuth token from the remote Martini runtime server."
-  type        = string
-}
-
-variable "client_id" {
-  description = "OAuth client ID for authentication. Default is TOROMartini."
-  type        = string
-}
-
-variable "client_secret" {
-  description = "OAuth client secret for authentication."
-  type        = string
-}


### PR DESCRIPTION
These changes implement the use of long-lived access tokens, eliminating the need to fetch OAuth tokens for authenticating with remote Martini Runtime Servers.

Adds the following parameter and variable:
- MARTINI_ACCESS_TOKEN 

Removes the following parameters and variables:
- MARTINI_USER_NAME
- MARTINI_USER_PASSWORD
- CLIENT_ID
- CLIENT_SECRET